### PR TITLE
Fix Windows installation documentation - clarify WSL requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Lue - Terminal eBook Reader with Text-to-Speech
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)](https://github.com/superstarryeyes/lue)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(WSL)-lightgrey)](https://github.com/superstarryeyes/lue)
 [![Terminal](https://img.shields.io/badge/interface-terminal-blue.svg)](https://github.com/superstarryeyes/lue)
 [![Discord](https://img.shields.io/badge/Discord-Join%20our%20Community-5865F2?logo=discord&logoColor=white)](https://discord.gg/z8sE2gnMNk)
 
@@ -23,7 +23,7 @@
 | --------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | **📖 Multi-Format Support**             | Support for EPUB, PDF, TXT, DOCX, DOC, HTML, RTF, and Markdown with seamless format detection  |
 | **👄 Modular TTS System**               | Edge TTS (default) and Kokoro TTS (local/offline) with extensible architecture for new models  |
-| **🌍 Cross-Platform & Multilingual**    | Full support for macOS, Linux, Windows with 100+ languages and consistent global experience    |
+| **🌍 Cross-Platform & Multilingual**    | Full support for macOS, Linux, Windows (via WSL) with 100+ languages and consistent global experience    |
 | **🎛️ Speed Adjustment**                 | Adjust text-to-speech playback speed from 1x to 3x for personalized listening experience       |
 | **🎯 Precise Word Highlighting**        | Word-level highlighting synchronized with actual speech, improving focus and concentration     |
 | **🌌 Rich Terminal UI**                 | Clean, responsive interface with customizable color themes and full mouse & keyboard support   |
@@ -35,7 +35,7 @@
 
 ## 🚀 Quick Start
 
-> **Want to try Lue right away?** Follow these simple steps:
+### macOS and Linux
 
 ```bash
 # 1. Install FFmpeg (required for audio processing)
@@ -43,7 +43,6 @@
 brew install ffmpeg
 # Ubuntu/Debian  
 sudo apt install ffmpeg
-# Windows: Download from ffmpeg.org and add to PATH
 
 # 2. Install the latest version from PyPI
 pip install git+https://github.com/superstarryeyes/lue.git
@@ -53,6 +52,28 @@ lue --guide
 
 # 4. Start reading!
 lue path/to/your/book.epub 
+```
+
+### Windows
+
+**⚠️ Important:** Native Windows installation currently has compatibility issues. **Use WSL for best experience.**
+
+```bash
+# 1. Install WSL (Windows Subsystem for Linux)
+# Open PowerShell as Administrator and run:
+wsl --install
+
+# 2. Restart your PC if prompted, then launch Ubuntu from Start Menu
+
+# 3. Inside Ubuntu terminal:
+sudo apt update && sudo apt upgrade -y
+sudo apt install ffmpeg python3 python3-pip -y
+
+# 4. Install Lue
+pip3 install git+https://github.com/superstarryeyes/lue.git
+
+# 5. Start reading!
+lue path/to/your/book.epub
 ```
 
 > **📝 Note:** Quick start uses Edge TTS (requires internet). For offline capabilities, see [full installation](#-installation).
@@ -70,6 +91,8 @@ lue path/to/your/book.epub
 - **espeak** - Kokoro TTS support
 - **antiword** - .doc file support
 
+### Platform-Specific Setup
+
 #### macOS (Homebrew)
 ```bash
 brew install ffmpeg
@@ -85,11 +108,42 @@ sudo apt install espeak antiword
 ```
 
 #### Windows
-Download FFmpeg from [ffmpeg.org](https://ffmpeg.org/download.html) and add to PATH.
+
+**⚠️ Windows Native Installation Issues**
+
+Currently, Lue has compatibility issues on native Windows due to Unix-specific dependencies (`termios` module). **We strongly recommend using WSL for Windows users.**
+
+**Option 1: WSL (Recommended)**
+```bash
+# 1. Install WSL
+# Open PowerShell as Administrator:
+wsl --install
+
+# 2. Restart PC if prompted, launch Ubuntu from Start Menu
+
+# 3. Follow Ubuntu installation steps above
+```
+
+**Option 2: Native Windows (Experimental)**
+⚠️ **Warning:** Native Windows support is currently broken and may not work.
+
+If you want to attempt native installation anyway:
+```bash
+# Download FFmpeg from ffmpeg.org and add to PATH
+# Then try (but expect errors):
+pip install git+https://github.com/superstarryeyes/lue.git
+```
+
+**Known Issues on Windows:**
+- `ModuleNotFoundError: No module named 'termios'` - Unix-only module
+- Terminal control issues
+- Audio playback problems
+
+> **💡 Help Wanted:** We're looking for contributors to help fix Windows native support! See [Contributing](#-contributing) if you're interested in helping.
 
 ### Install Lue
 
-#### Standard Installation
+#### Standard Installation (macOS/Linux/WSL)
 
 ```bash
 # 1. Clone repository
@@ -207,12 +261,14 @@ Check out the [Developer Guide](DEVELOPER.md) for instructions on adding new TTS
 **Reading Progress:**
 - **macOS:** `~/Library/Application Support/lue/`
 - **Linux:** `~/.local/share/lue/`  
-- **Windows:** `C:\Users\<User>\AppData\Local\lue\`
+- **Windows (WSL):** `~/.local/share/lue/` (within WSL filesystem)
+- **Windows (Native):** `C:\Users\<User>\AppData\Local\lue\` *(if working)*
 
 **Error Logs:**
 - **macOS:** `~/Library/Logs/lue/error.log`
 - **Linux:** `~/.cache/lue/log/error.log`
-- **Windows:** `C:\Users\<User>\AppData\Local\lue\Logs\error.log`
+- **Windows (WSL):** `~/.cache/lue/log/error.log` (within WSL filesystem)
+- **Windows (Native):** `C:\Users\<User>\AppData\Local\lue\Logs\error.log` *(if working)*
 
 ---
 
@@ -225,6 +281,11 @@ This project is licensed under the **GPL-3.0 License** - see the [LICENSE](LICEN
 ## 🛠️ Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
+
+**Priority Help Needed:**
+- **Windows Native Support:** Fix `termios` compatibility issues and improve Windows support
+- **Cross-platform Testing:** Help test on different Windows versions
+- **Documentation:** Improve installation guides and troubleshooting
 
 <div align="center">
 


### PR DESCRIPTION
- Add clear warnings about Windows native compatibility issues
    - Provide complete WSL installation instructions as recommended solution  
    - Update platform badge to reflect actual support (Windows via WSL)
    - Add troubleshooting section with known Windows issues
    - Add call for contributors to help fix native Windows support
    
    Fixes ModuleNotFoundError: No module named 'termios' on Windows