### PR TITLE
fix: j to go `next_sentence` and k to go `prev_sentence`

### DIFF
--- a/lue/keys_default.json
+++ b/lue/keys_default.json
@@ -2,8 +2,8 @@
   "navigation": {
     "next_paragraph": "l",
     "prev_paragraph": "h",
-    "next_sentence": "k",
-    "prev_sentence": "j",
+    "next_sentence": "j",
+    "prev_sentence": "k",
     "scroll_page_up": "i",
     "scroll_page_down": "m",
     "scroll_up": "u",


### PR DESCRIPTION
Hope you're doing well!

You can't believe how excited I am to have found this software! I really like edge TTS but hate having to open the edge browser (not to mention having to install it) just to use its Read aloud TTS feature. I used https://github.com/rany2/edge-tts but there is no word-level highlighting. So lue is the perfect solution for me! I could not have asked for a better solution (TTS with word-level highlighting in the terminal!)

Thank you so much!