### PR TITLE
Add MiniMax Cloud TTS provider (speech-2.8-hd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 | **Feature**                             | **Description**                                                                                |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | **📖 Multi-Format Support**             | Support for EPUB, PDF, TXT, DOCX, DOC, HTML, RTF, and Markdown with seamless format detection  |
-| **👄 Modular TTS System**               | Edge TTS (default) and Kokoro TTS (local/offline) with extensible architecture for new models  |
+| **👄 Modular TTS System**               | Edge TTS (default), Kokoro TTS (local/offline), and [MiniMax Cloud TTS](https://platform.minimaxi.com/) with extensible architecture for new models  |
 | **🌍 Cross-Platform & Multilingual**    | Full support for macOS, Linux, Windows (via WSL) with 100+ languages and consistent global experience    |
 | **🎛️ Speed Adjustment**                 | Adjust text-to-speech playback speed from 1x to 3x for personalized listening experience       |
 | **🎯 Auto-Scroll & Precise Word Highlighting**        | Automatic scrolling and word-level highlighting synchronized with actual speech, improving focus and concentration     |
@@ -142,6 +142,27 @@ pip install -r requirements.txt
 
 # 4. Install Lue
 pip install .
+```
+
+#### Enable MiniMax Cloud TTS (Optional)
+
+For high-quality cloud-based TTS using the [MiniMax](https://platform.minimaxi.com/) speech-2.8-hd model:
+
+```bash
+# 1. Install the requests library
+pip install requests
+
+# Or install via optional dependency:
+pip install ".[minimax]"
+
+# 2. Set your MiniMax API key
+export MINIMAX_API_KEY="your-api-key-here"
+
+# 3. Use MiniMax TTS
+lue --tts minimax path/to/your/book.epub
+
+# 4. Optionally select a voice (see VOICES.md for the full list)
+lue --tts minimax --voice English_Persuasive_Man path/to/your/book.epub
 ```
 
 ---

--- a/VOICES.md
+++ b/VOICES.md
@@ -659,3 +659,27 @@ Edge TTS provides a wide variety of voices across many languages. Always include
 *   pf_dora (Female)
 *   pm_alex (Male)
 *   pm_santa (Male)
+
+***
+
+### MiniMax Cloud Voices
+
+MiniMax Cloud TTS uses the `speech-2.8-hd` model and requires an API key. Set the `MINIMAX_API_KEY` environment variable before use.
+
+#### English
+
+*   **English_Graceful_Lady** (Female) - Default MiniMax voice
+*   English_Insightful_Speaker (Male)
+*   English_radiant_girl (Female)
+*   English_Persuasive_Man (Male)
+*   English_Lucky_Robot (Neutral)
+
+#### Multilingual
+
+*   Wise_Woman (Female)
+*   cute_boy (Male)
+*   lovely_girl (Female)
+*   Friendly_Person (Neutral)
+*   Inspirational_girl (Female)
+*   Deep_Voice_Man (Male)
+*   sweet_girl (Female)

--- a/lue/config.py
+++ b/lue/config.py
@@ -10,6 +10,7 @@ DEFAULT_TTS_MODEL = "edge"
 TTS_VOICES = {
     "edge": "en-US-JennyNeural",
     "kokoro": "af_heart",
+    "minimax": "English_Graceful_Lady",
 }
 
 # Language codes for TTS models that require them

--- a/lue/tts/minimax_tts.py
+++ b/lue/tts/minimax_tts.py
@@ -1,0 +1,185 @@
+"""MiniMax Cloud TTS model for the Lue eBook reader.
+
+Uses the MiniMax Text-to-Speech API (speech-2.8-hd model) for high-quality
+cloud-based speech synthesis. Requires a MINIMAX_API_KEY environment variable
+and internet access.
+
+API Reference: https://platform.minimaxi.com/document/T2A%20V2
+"""
+
+import os
+import asyncio
+import logging
+from rich.console import Console
+
+from .base import TTSBase
+from .. import config
+
+
+# Verified MiniMax voice IDs
+MINIMAX_VOICES = [
+    "English_Graceful_Lady",
+    "English_Insightful_Speaker",
+    "English_radiant_girl",
+    "English_Persuasive_Man",
+    "English_Lucky_Robot",
+    "Wise_Woman",
+    "cute_boy",
+    "lovely_girl",
+    "Friendly_Person",
+    "Inspirational_girl",
+    "Deep_Voice_Man",
+    "sweet_girl",
+]
+
+
+class MiniMaxTTS(TTSBase):
+    """TTS implementation for MiniMax Cloud Text-to-Speech API.
+
+    Uses the speech-2.8-hd model via the /v1/t2a_v2 endpoint.
+    Requires the MINIMAX_API_KEY environment variable to be set.
+    """
+
+    API_URL = "https://api.minimax.io/v1/t2a_v2"
+    MODEL = "speech-2.8-hd"
+
+    @property
+    def name(self) -> str:
+        return "minimax"
+
+    @property
+    def output_format(self) -> str:
+        return "mp3"
+
+    def __init__(self, console: Console, voice: str = None, lang: str = None):
+        super().__init__(console, voice, lang)
+        self.api_key = None
+        self.requests = None
+
+        if self.voice is None:
+            self.voice = config.TTS_VOICES.get(self.name)
+
+    async def initialize(self) -> bool:
+        """Check for the requests library and a valid MINIMAX_API_KEY."""
+        try:
+            import requests
+            self.requests = requests
+        except ImportError:
+            self.console.print(
+                "[bold red]Error: 'requests' package not found.[/bold red]"
+            )
+            self.console.print(
+                "[yellow]Please run 'pip install requests' to use MiniMax TTS.[/yellow]"
+            )
+            logging.error("'requests' is not installed for MiniMax TTS.")
+            return False
+
+        self.api_key = os.environ.get("MINIMAX_API_KEY")
+        if not self.api_key:
+            self.console.print(
+                "[bold red]Error: MINIMAX_API_KEY environment variable not set.[/bold red]"
+            )
+            self.console.print(
+                "[yellow]Please set MINIMAX_API_KEY to use MiniMax Cloud TTS.[/yellow]"
+            )
+            logging.error("MINIMAX_API_KEY is not set.")
+            return False
+
+        self.initialized = True
+        self.console.print("[green]MiniMax Cloud TTS is available.[/green]")
+        return True
+
+    def _call_api(self, text: str) -> bytes:
+        """Call the MiniMax TTS API and return raw MP3 audio bytes.
+
+        Args:
+            text: Text to synthesize.
+
+        Returns:
+            Raw MP3 audio bytes.
+
+        Raises:
+            RuntimeError: On API errors or unexpected responses.
+        """
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": self.MODEL,
+            "text": text,
+            "voice_setting": {
+                "voice_id": self.voice,
+            },
+            "audio_setting": {
+                "format": "mp3",
+            },
+        }
+
+        response = self.requests.post(
+            self.API_URL, headers=headers, json=payload, timeout=60
+        )
+        response.raise_for_status()
+
+        data = response.json()
+
+        # Check for API-level errors
+        if data.get("base_resp", {}).get("status_code", 0) != 0:
+            error_msg = data.get("base_resp", {}).get("status_msg", "Unknown error")
+            raise RuntimeError(f"MiniMax TTS API error: {error_msg}")
+
+        audio_hex = data.get("data", {}).get("audio")
+        if not audio_hex:
+            raise RuntimeError("MiniMax TTS API returned no audio data.")
+
+        return bytes.fromhex(audio_hex)
+
+    async def generate_audio(self, text: str, output_path: str):
+        """Generate audio from text using MiniMax Cloud TTS."""
+        if not self.initialized:
+            raise RuntimeError("MiniMax TTS has not been initialized.")
+
+        loop = asyncio.get_running_loop()
+
+        def _blocking_generate():
+            try:
+                audio_bytes = self._call_api(text)
+                with open(output_path, "wb") as f:
+                    f.write(audio_bytes)
+            except Exception as e:
+                logging.error(
+                    f"MiniMax TTS audio generation failed for text: '{text[:50]}...'",
+                    exc_info=True,
+                )
+                raise e
+
+        await loop.run_in_executor(None, _blocking_generate)
+
+    async def warm_up(self):
+        """Warm up by making a short API request."""
+        if not self.initialized:
+            return
+
+        self.console.print(
+            "[bold cyan]Warming up MiniMax Cloud TTS...[/bold cyan]"
+        )
+        warmup_file = os.path.join(
+            config.AUDIO_DATA_DIR, f".warmup_minimax.{self.output_format}"
+        )
+        try:
+            await self.generate_audio("Ready.", warmup_file)
+            self.console.print("[green]MiniMax Cloud TTS is ready.[/green]")
+        except Exception as e:
+            self.console.print(
+                "[bold yellow]Warning: MiniMax TTS warm-up failed.[/bold yellow]"
+            )
+            self.console.print(
+                f"[yellow]This may indicate a network issue or an invalid API key.[/yellow]"
+            )
+            logging.warning(f"MiniMax TTS warm-up failed: {e}", exc_info=True)
+        finally:
+            if os.path.exists(warmup_file):
+                try:
+                    os.remove(warmup_file)
+                except OSError:
+                    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ kokoro = [
     "soundfile>=0.13.1",
     "huggingface-hub>=0.34.4",
 ]
+minimax = [
+    "requests>=2.28.0",
+]
 
 [project.scripts]
 lue = "lue.__main__:cli"

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ edge-tts>=7.2.7
 # kokoro>=0.9.4
 # soundfile>=0.13.1
 # huggingface-hub>=0.34.4
+
+## For MiniMax Cloud TTS (requires MINIMAX_API_KEY environment variable):
+# requests>=2.28.0

--- a/tests/test_minimax_tts.py
+++ b/tests/test_minimax_tts.py
@@ -1,0 +1,361 @@
+"""Unit tests for MiniMax Cloud TTS provider."""
+
+import json
+import os
+import sys
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+# Add parent directory to path so we can import lue modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from lue.tts.minimax_tts import MiniMaxTTS, MINIMAX_VOICES
+from lue.tts.base import TTSBase
+
+
+class TestMiniMaxTTSProperties(unittest.TestCase):
+    """Test MiniMaxTTS class properties and constants."""
+
+    def setUp(self):
+        self.console = MagicMock()
+        self.tts = MiniMaxTTS(self.console)
+
+    def test_name(self):
+        self.assertEqual(self.tts.name, "minimax")
+
+    def test_output_format(self):
+        self.assertEqual(self.tts.output_format, "mp3")
+
+    def test_inherits_tts_base(self):
+        self.assertIsInstance(self.tts, TTSBase)
+
+    def test_api_url(self):
+        self.assertEqual(
+            MiniMaxTTS.API_URL, "https://api.minimax.io/v1/t2a_v2"
+        )
+
+    def test_model_name(self):
+        self.assertEqual(MiniMaxTTS.MODEL, "speech-2.8-hd")
+
+    def test_default_voice_from_config(self):
+        """Default voice should come from config when none provided."""
+        tts = MiniMaxTTS(self.console)
+        self.assertEqual(tts.voice, "English_Graceful_Lady")
+
+    def test_custom_voice(self):
+        """Custom voice should override default."""
+        tts = MiniMaxTTS(self.console, voice="Deep_Voice_Man")
+        self.assertEqual(tts.voice, "Deep_Voice_Man")
+
+    def test_voices_list(self):
+        """All verified voice IDs should be in the list."""
+        self.assertIn("English_Graceful_Lady", MINIMAX_VOICES)
+        self.assertIn("Deep_Voice_Man", MINIMAX_VOICES)
+        self.assertIn("sweet_girl", MINIMAX_VOICES)
+        self.assertEqual(len(MINIMAX_VOICES), 12)
+
+
+class TestMiniMaxTTSInitialize(unittest.TestCase):
+    """Test MiniMaxTTS initialization."""
+
+    def setUp(self):
+        self.console = MagicMock()
+
+    def test_initialize_missing_requests(self):
+        """Should fail gracefully when requests is not installed."""
+        tts = MiniMaxTTS(self.console)
+        with patch.dict("sys.modules", {"requests": None}):
+            with patch("builtins.__import__", side_effect=ImportError("No module named 'requests'")):
+                result = asyncio.get_event_loop().run_until_complete(
+                    tts.initialize()
+                )
+        self.assertFalse(result)
+        self.assertFalse(tts.initialized)
+
+    def test_initialize_missing_api_key(self):
+        """Should fail when MINIMAX_API_KEY is not set."""
+        tts = MiniMaxTTS(self.console)
+        with patch.dict(os.environ, {}, clear=True):
+            # Ensure MINIMAX_API_KEY is not set
+            os.environ.pop("MINIMAX_API_KEY", None)
+            result = asyncio.get_event_loop().run_until_complete(
+                tts.initialize()
+            )
+        self.assertFalse(result)
+        self.assertFalse(tts.initialized)
+
+    def test_initialize_success(self):
+        """Should succeed when requests is available and API key is set."""
+        tts = MiniMaxTTS(self.console)
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"}):
+            result = asyncio.get_event_loop().run_until_complete(
+                tts.initialize()
+            )
+        self.assertTrue(result)
+        self.assertTrue(tts.initialized)
+        self.assertEqual(tts.api_key, "test-key-123")
+
+    def test_initialize_stores_api_key(self):
+        """API key should be stored for later use."""
+        tts = MiniMaxTTS(self.console)
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "my-secret-key"}):
+            asyncio.get_event_loop().run_until_complete(tts.initialize())
+        self.assertEqual(tts.api_key, "my-secret-key")
+
+
+class TestMiniMaxTTSCallAPI(unittest.TestCase):
+    """Test the _call_api method."""
+
+    def setUp(self):
+        self.console = MagicMock()
+        self.tts = MiniMaxTTS(self.console)
+        self.tts.api_key = "test-key"
+        self.tts.initialized = True
+
+        import requests
+        self.tts.requests = requests
+
+    @patch("requests.post")
+    def test_call_api_success(self, mock_post):
+        """Should return decoded audio bytes on success."""
+        # "hello" in hex
+        audio_hex = b"hello world".hex()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "base_resp": {"status_code": 0},
+            "data": {"audio": audio_hex},
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        result = self.tts._call_api("Test text")
+        self.assertEqual(result, b"hello world")
+
+        # Verify API call
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        self.assertIn("Authorization", call_kwargs.kwargs.get("headers", call_kwargs[1].get("headers", {})))
+
+    @patch("requests.post")
+    def test_call_api_sends_correct_payload(self, mock_post):
+        """Should send correct model, voice, and format."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "base_resp": {"status_code": 0},
+            "data": {"audio": "aabb"},
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        self.tts._call_api("Hello")
+
+        call_args = mock_post.call_args
+        payload = call_args.kwargs.get("json", call_args[1].get("json", {}))
+        self.assertEqual(payload["model"], "speech-2.8-hd")
+        self.assertEqual(payload["text"], "Hello")
+        self.assertEqual(
+            payload["voice_setting"]["voice_id"], "English_Graceful_Lady"
+        )
+        self.assertEqual(payload["audio_setting"]["format"], "mp3")
+
+    @patch("requests.post")
+    def test_call_api_error_status(self, mock_post):
+        """Should raise RuntimeError on API error status."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "base_resp": {
+                "status_code": 1001,
+                "status_msg": "Invalid API key",
+            },
+            "data": {},
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.tts._call_api("Test")
+        self.assertIn("Invalid API key", str(ctx.exception))
+
+    @patch("requests.post")
+    def test_call_api_no_audio_data(self, mock_post):
+        """Should raise RuntimeError when no audio data returned."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "base_resp": {"status_code": 0},
+            "data": {},
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.tts._call_api("Test")
+        self.assertIn("no audio data", str(ctx.exception))
+
+    @patch("requests.post")
+    def test_call_api_http_error(self, mock_post):
+        """Should propagate HTTP errors."""
+        import requests
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.HTTPError(
+            "500 Server Error"
+        )
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(requests.HTTPError):
+            self.tts._call_api("Test")
+
+    @patch("requests.post")
+    def test_call_api_bearer_auth(self, mock_post):
+        """Should use Bearer token authentication."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "base_resp": {"status_code": 0},
+            "data": {"audio": "aabb"},
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        self.tts._call_api("Test")
+
+        call_args = mock_post.call_args
+        headers = call_args.kwargs.get("headers", call_args[1].get("headers", {}))
+        self.assertEqual(headers["Authorization"], "Bearer test-key")
+
+
+class TestMiniMaxTTSGenerateAudio(unittest.TestCase):
+    """Test generate_audio method."""
+
+    def setUp(self):
+        self.console = MagicMock()
+        self.tts = MiniMaxTTS(self.console)
+        self.tts.api_key = "test-key"
+        self.tts.initialized = True
+
+        import requests
+        self.tts.requests = requests
+
+    def test_generate_audio_not_initialized(self):
+        """Should raise RuntimeError when not initialized."""
+        tts = MiniMaxTTS(self.console)
+        with self.assertRaises(RuntimeError):
+            asyncio.get_event_loop().run_until_complete(
+                tts.generate_audio("Test", "/tmp/test.mp3")
+            )
+
+    @patch("requests.post")
+    def test_generate_audio_writes_file(self, mock_post):
+        """Should write audio bytes to the output file."""
+        audio_bytes = b"\xff\xfb\x90\x00"  # Fake MP3 header
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "base_resp": {"status_code": 0},
+            "data": {"audio": audio_bytes.hex()},
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+            output_path = f.name
+
+        try:
+            asyncio.get_event_loop().run_until_complete(
+                self.tts.generate_audio("Test text", output_path)
+            )
+            with open(output_path, "rb") as f:
+                written = f.read()
+            self.assertEqual(written, audio_bytes)
+        finally:
+            os.unlink(output_path)
+
+
+class TestMiniMaxTTSWarmUp(unittest.TestCase):
+    """Test warm_up method."""
+
+    def setUp(self):
+        self.console = MagicMock()
+        self.tts = MiniMaxTTS(self.console)
+        self.tts.api_key = "test-key"
+        self.tts.initialized = True
+
+        import requests
+        self.tts.requests = requests
+
+    def test_warm_up_not_initialized(self):
+        """Should silently return when not initialized."""
+        tts = MiniMaxTTS(self.console)
+        # Should not raise
+        asyncio.get_event_loop().run_until_complete(tts.warm_up())
+
+    @patch("requests.post")
+    def test_warm_up_success(self, mock_post):
+        """Should complete without error on success."""
+        audio_bytes = b"\xff\xfb\x90\x00"
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "base_resp": {"status_code": 0},
+            "data": {"audio": audio_bytes.hex()},
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        asyncio.get_event_loop().run_until_complete(self.tts.warm_up())
+
+    @patch("requests.post")
+    def test_warm_up_failure_handled(self, mock_post):
+        """Should handle warm-up failure gracefully."""
+        mock_post.side_effect = Exception("Network error")
+
+        # Should not raise
+        asyncio.get_event_loop().run_until_complete(self.tts.warm_up())
+
+
+class TestMiniMaxTTSAutoDiscovery(unittest.TestCase):
+    """Test that MiniMax TTS is discoverable by TTSManager."""
+
+    def test_module_follows_naming_convention(self):
+        """File must be named *_tts.py for auto-discovery."""
+        tts_dir = os.path.join(
+            os.path.dirname(__file__), "..", "lue", "tts"
+        )
+        minimax_file = os.path.join(tts_dir, "minimax_tts.py")
+        self.assertTrue(
+            os.path.exists(minimax_file),
+            "minimax_tts.py must exist in lue/tts/ for auto-discovery",
+        )
+
+    def test_tts_manager_discovers_minimax(self):
+        """TTSManager should discover the minimax model."""
+        from lue.tts_manager import TTSManager
+
+        manager = TTSManager()
+        available = manager.get_available_tts_names()
+        self.assertIn("minimax", available)
+
+    def test_tts_manager_creates_minimax(self):
+        """TTSManager should be able to create a MiniMax instance."""
+        from lue.tts_manager import TTSManager
+
+        manager = TTSManager()
+        console = MagicMock()
+        model = manager.create_model("minimax", console)
+        self.assertIsNotNone(model)
+        self.assertIsInstance(model, MiniMaxTTS)
+        self.assertEqual(model.name, "minimax")
+
+
+class TestMiniMaxTTSConfig(unittest.TestCase):
+    """Test MiniMax entries in config.py."""
+
+    def test_default_voice_in_config(self):
+        from lue import config
+
+        self.assertIn("minimax", config.TTS_VOICES)
+        self.assertEqual(
+            config.TTS_VOICES["minimax"], "English_Graceful_Lady"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minimax_tts_integration.py
+++ b/tests/test_minimax_tts_integration.py
@@ -1,0 +1,89 @@
+"""Integration tests for MiniMax Cloud TTS provider.
+
+These tests call the real MiniMax TTS API and require:
+  - MINIMAX_API_KEY environment variable to be set
+  - Network access to api.minimax.io
+
+Skip automatically when the API key is not available.
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY")
+SKIP_REASON = "MINIMAX_API_KEY not set; skipping live API tests"
+
+
+@unittest.skipUnless(MINIMAX_API_KEY, SKIP_REASON)
+class TestMiniMaxTTSIntegration(unittest.TestCase):
+    """Live integration tests against the MiniMax TTS API."""
+
+    def setUp(self):
+        from unittest.mock import MagicMock
+        from lue.tts.minimax_tts import MiniMaxTTS
+
+        self.console = MagicMock()
+        self.tts = MiniMaxTTS(self.console)
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+        initialized = self.loop.run_until_complete(self.tts.initialize())
+        self.assertTrue(initialized, "MiniMax TTS should initialize with valid API key")
+
+    def tearDown(self):
+        self.loop.close()
+
+    def test_generate_short_text(self):
+        """Should generate a valid MP3 file from short text."""
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+            output_path = f.name
+
+        try:
+            self.loop.run_until_complete(
+                self.tts.generate_audio("Hello, world.", output_path)
+            )
+            self.assertTrue(os.path.exists(output_path))
+            size = os.path.getsize(output_path)
+            self.assertGreater(size, 100, "MP3 file should be non-trivial")
+
+            # Verify it looks like an MP3 (check for common MP3 signatures)
+            with open(output_path, "rb") as f:
+                header = f.read(4)
+            # MP3 files typically start with 0xFF 0xFB or ID3 tag
+            is_mp3 = header[:2] == b"\xff\xfb" or header[:3] == b"ID3"
+            self.assertTrue(is_mp3, f"File should be MP3, got header: {header.hex()}")
+        finally:
+            os.unlink(output_path)
+
+    def test_generate_with_custom_voice(self):
+        """Should generate audio with a different voice."""
+        from unittest.mock import MagicMock
+        from lue.tts.minimax_tts import MiniMaxTTS
+
+        tts = MiniMaxTTS(MagicMock(), voice="Deep_Voice_Man")
+        self.loop.run_until_complete(tts.initialize())
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+            output_path = f.name
+
+        try:
+            self.loop.run_until_complete(
+                tts.generate_audio("Testing with a deep voice.", output_path)
+            )
+            self.assertTrue(os.path.exists(output_path))
+            self.assertGreater(os.path.getsize(output_path), 100)
+        finally:
+            os.unlink(output_path)
+
+    def test_warm_up(self):
+        """Warm-up should complete without error."""
+        self.loop.run_until_complete(self.tts.warm_up())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add **MiniMax Cloud TTS** as a new text-to-speech provider for Lue, using the [speech-2.8-hd](https://platform.minimaxi.com/document/T2A%20V2) model via the `/v1/t2a_v2` API endpoint.

### What's included

- **New TTS provider** (`lue/tts/minimax_tts.py`): Follows the `TTSBase` contract and is auto-discovered by `TTSManager` — no changes to the core discovery logic needed
- **12 verified voice IDs**: `English_Graceful_Lady` (default), `English_Insightful_Speaker`, `English_radiant_girl`, `English_Persuasive_Man`, `English_Lucky_Robot`, `Wise_Woman`, `cute_boy`, `lovely_girl`, `Friendly_Person`, `Inspirational_girl`, `Deep_Voice_Man`, `sweet_girl`
- **Optional dependency**: `requests` library, installable via `pip install ".[minimax]"`
- **Full test suite**: 27 unit tests + 3 integration tests (auto-skipped without API key)
- **Documentation**: Updated `README.md`, `VOICES.md`, `requirements.txt`, and `pyproject.toml`

### Usage

```bash
export MINIMAX_API_KEY="your-api-key"
lue --tts minimax path/to/book.epub

# With a specific voice
lue --tts minimax --voice Deep_Voice_Man path/to/book.epub
```

### Architecture

The implementation follows the same patterns as the existing Edge TTS and Kokoro TTS providers:
- Extends `TTSBase` abstract base class
- Uses `asyncio.get_running_loop().run_in_executor()` for non-blocking API calls
- Graceful fallback when `requests` is not installed or API key is missing
- Output format: MP3 (hex-decoded from API response)

## Test plan

- [x] All 27 unit tests pass (`python -m pytest tests/test_minimax_tts.py`)
- [x] All 3 integration tests pass with valid API key (`python -m pytest tests/test_minimax_tts_integration.py`)
- [x] `TTSManager` auto-discovers the new `minimax` provider
- [x] `--tts minimax` appears in CLI help text
- [ ] Manual test: `lue --tts minimax book.epub` plays audio correctly